### PR TITLE
Support for PSN caching

### DIFF
--- a/nginx/config/vhosts/psn.conf
+++ b/nginx/config/vhosts/psn.conf
@@ -1,0 +1,131 @@
+# PSN Node
+
+server {
+    listen 80;
+    server_name .ps4.update.playstation.net;
+
+    # PS4 update files
+    # * Server doesn't provide any caching information, so we have to be very
+    #   explicit with what we're caching
+    # * Firmware files are identical across regions (despite differing
+    #   servers and query parameters) so we will cache based on URI alone
+
+
+    location /update/ps4/list/ {
+        # Update lists
+        # * Unique per region - XML is region tagged
+        # * Can change at any point, so revalidate
+        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_valid 200 1m;
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location /update/ps4/image/ {
+        # Update images
+        # * Identical across regions
+        # * Won't change, so cache
+        # * Large, so slice
+        slice 16m;
+        proxy_set_header Range $slice_range;
+        proxy_hide_header Etag;
+        proxy_cache_key "qcacher-psn$uri$slice_range";
+        proxy_cache_valid 200 206 14d;
+        proxy_cache installs;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+}
+
+server {
+    listen 80;
+    server_name .dl.playstation.net;
+
+    # PSN downloads
+
+    location /gs2/ {
+        # PSN application content
+
+        # Handle redirects to 3rd party CDNs
+        error_page 301 302 307 = @gs2_redirect;
+        recursive_error_pages on;
+        proxy_intercept_errors on;
+
+        # Range requests are guaranteed and we have large assets so we'll
+        # slice in 16MB chunks and cache
+        slice 16m;
+        proxy_cache_valid 200 206 14d;
+        proxy_set_header Range $slice_range;
+
+        # Looks like PS passes security parameters on the URI so we
+        # cache based on just the URI excluding the query string
+        proxy_cache_key "qcacher-psn$uri$slice_range";
+
+        # PSN's Cache-Control and Expires are restrictive
+        proxy_ignore_headers Expires Cache-Control;
+        proxy_hide_header Etag;
+
+        proxy_cache installs;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location /tmdb2/ {
+        # PSN application info tickets
+
+        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_valid 200 1m;
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location ~ ^/(nsx|psn-rsc)/ {
+        # thumbnails, etc
+        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_valid 200 14d;
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location /networktest/ {
+        # Showing off the cache speed
+        proxy_cache_key "qcacher-psn$uri";
+        proxy_cache_valid 200 90d;
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location / {
+        # Just pass through everything else
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    # Process a redirect and cache the response
+    location @gs2_redirect {
+
+        # Range requests are guaranteed and we have large assets so we'll
+        # slice in 16MB chunks and cache
+        slice 16m;
+        proxy_cache_valid 200 206 14d;
+        proxy_set_header Range $slice_range;
+
+        # Looks like PS passes security parameters on the URI so we
+        # cache based on just the URI excluding the query string
+        proxy_cache_key "qcacher-psn$uri$slice_range";
+
+        # PSN's Cache-Control and Expires are restrictive
+        proxy_ignore_headers Expires Cache-Control;
+        proxy_hide_header Etag;
+
+        proxy_cache installs;
+        include includes/proxy-base;
+        # We need to copy the variable as it's not available after the pass starts
+        set $location $upstream_http_location;
+        proxy_pass $location;
+    }
+}

--- a/nginx/config/vhosts/psn.conf
+++ b/nginx/config/vhosts/psn.conf
@@ -2,16 +2,17 @@
 
 server {
     listen 80;
-    server_name .ps4.update.playstation.net;
+    server_name .ps3.update.playstation.net
+                .ps4.update.playstation.net;
 
-    # PS4 update files
+    # PS firmware update files
     # * Server doesn't provide any caching information, so we have to be very
     #   explicit with what we're caching
     # * Firmware files are identical across regions (despite differing
     #   servers and query parameters) so we will cache based on URI alone
 
 
-    location /update/ps4/list/ {
+    location ~ ^/update/ps(3|4)/list/ {
         # Update lists
         # * Unique per region - XML is region tagged
         # * Can change at any point, so revalidate
@@ -22,7 +23,7 @@ server {
         proxy_pass http://$host$request_uri;
     }
 
-    location /update/ps4/image/ {
+    location ~ ^/update/ps(3|4)/image/ {
         # Update images
         # * Identical across regions
         # * Won't change, so cache
@@ -36,19 +37,75 @@ server {
         include includes/proxy-base;
         proxy_pass http://$host$request_uri;
     }
+
+    location / {
+        # Just pass through everything else
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
 }
 
 server {
     listen 80;
-    server_name .dl.playstation.net;
+    server_name apollo.dl.playstation.net
+                apollo2.dl.playstation.net
+                nsx.np.dl.playstation.net
+                nsx-e.np.dl.playstation.net
+                psn-rsc.prod.dl.playstation.net;
 
-    # PSN downloads
+    # Application thumbnails, etc
+    # * Apollo used by PS3
+    # * NSX used by both PS3 & PS4
+    # * PSN-RSC used by PS4
 
-    location /gs2/ {
+    location / {
+        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_valid 200 14d;
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+}
+
+server {
+    listen 80;
+    server_name tmdb.np.dl.playstation.net;
+
+    # PSN Title Metadata
+    # * PS3 metadata at /tmdb/
+    # * PS4 metadata at /tmdb2/
+
+    location ~ /tmdb2?/ {
+
+        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_valid 200 1m;
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location / {
+        # Just pass through everything else
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+}
+
+server {
+    listen 80;
+    server_name ares.dl.playstation.net
+                zeus.dl.playstation.net
+                gs2.ww.prod.dl.playstation.net;
+
+    # PSN app content downloads
+    # * ares & zeus used by PS3
+    # * gs2 used by PS4
+
+    location ~ ^/(cdn|gs2)/ {
         # PSN application content
 
         # Handle redirects to 3rd party CDNs
-        error_page 301 302 307 = @gs2_redirect;
+        error_page 301 302 307 = @redirect;
         recursive_error_pages on;
         proxy_intercept_errors on;
 
@@ -71,42 +128,8 @@ server {
         proxy_pass http://$host$request_uri;
     }
 
-    location /tmdb2/ {
-        # PSN application info tickets
-
-        proxy_cache_key "qcacher-psn$request_uri";
-        proxy_cache_valid 200 1m;
-        proxy_cache other;
-        include includes/proxy-base;
-        proxy_pass http://$host$request_uri;
-    }
-
-    location ~ ^/(nsx|psn-rsc)/ {
-        # thumbnails, etc
-        proxy_cache_key "qcacher-psn$request_uri";
-        proxy_cache_valid 200 14d;
-        proxy_cache other;
-        include includes/proxy-base;
-        proxy_pass http://$host$request_uri;
-    }
-
-    location /networktest/ {
-        # Showing off the cache speed
-        proxy_cache_key "qcacher-psn$uri";
-        proxy_cache_valid 200 90d;
-        proxy_cache other;
-        include includes/proxy-base;
-        proxy_pass http://$host$request_uri;
-    }
-
-    location / {
-        # Just pass through everything else
-        include includes/proxy-base;
-        proxy_pass http://$host$request_uri;
-    }
-
     # Process a redirect and cache the response
-    location @gs2_redirect {
+    location @redirect {
 
         # Range requests are guaranteed and we have large assets so we'll
         # slice in 16MB chunks and cache
@@ -127,5 +150,20 @@ server {
         # We need to copy the variable as it's not available after the pass starts
         set $location $upstream_http_location;
         proxy_pass $location;
+    }
+
+    location /networktest/ {
+        # Showing off the cache speed
+        proxy_cache_key "qcacher-psn$uri";
+        proxy_cache_valid 200 90d;
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location / {
+        # Just pass through everything else
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
     }
 }

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -103,6 +103,17 @@ local-data: "akamai.cdn.ea.com. IN A 127.0.0.1"  # Origin
 local-data: "lvlt.cdn.ea.com. IN A 127.0.0.1"  # Origin
 
 
+# playstation.net
+
+local-zone: "playstation.net." transparent
+
+local-zone: "update.playstation.net." redirect
+local-data: "update.playstation.net. IN A 127.0.0.1"  # PSN
+
+local-zone: "dl.playstation.net." redirect
+local-data: "dl.playstation.net. IN A 127.0.0.1"  # PSN
+
+
 # sony.com
 
 local-zone: "sony.com." transparent

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -105,13 +105,19 @@ local-data: "lvlt.cdn.ea.com. IN A 127.0.0.1"  # Origin
 
 # playstation.net
 
-local-zone: "playstation.net." transparent
+local-zone: "dl.playstation.net." transparent
+local-data: "ares.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "apollo.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "apollo2.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "zeus.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "nsx.np.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "nsx-e.np.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "tmdb.np.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "psn-rsc.prod.dl.playstation.net. IN A 127.0.0.1"  # PSN
+local-data: "gs2.ww.prod.dl.playstation.net. IN A 127.0.0.1"  # PSN
 
 local-zone: "update.playstation.net." redirect
 local-data: "update.playstation.net. IN A 127.0.0.1"  # PSN
-
-local-zone: "dl.playstation.net." redirect
-local-data: "dl.playstation.net. IN A 127.0.0.1"  # PSN
 
 
 # sony.com


### PR DESCRIPTION
PSN was tricky as the PS3 doesn't send SNI information with HTTPS requests. This PR has however been tested with PS4 and PS3.
