### PR TITLE
New steam content server endpoints

### DIFF
--- a/nginx/config/vhosts/steam.conf
+++ b/nginx/config/vhosts/steam.conf
@@ -2,7 +2,7 @@
 
 server {
     listen 80;
-    server_name .cs.steampowered.com
+    server_name .steamcontent.com .cs.steampowered.com
                 content1.steampowered.com content2.steampowered.com
                 content3.steampowered.com content4.steampowered.com
                 content5.steampowered.com content6.steampowered.com

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -1,3 +1,8 @@
+# steamcontent.com
+
+local-zone: "steamcontent.com." redirect
+local-data: "steamcontent.com. IN A 127.0.0.1"  # Steam
+
 # steampowered.com
 
 local-zone: "steampowered.com." transparent


### PR DESCRIPTION
Steam recently added a new set of CDN endpoints and domain for content delivery, when not using the `LAN Event (Region)` setting. These content servers provide the same data as the original set. I've added configuration to handle data that lives at these servers, and qcacher will now cache data for those not specifically set to LAN Event.
