### PR TITLE
Addition of worldwide service to League CDN

### DIFF
--- a/nginx/config/vhosts/riot.conf
+++ b/nginx/config/vhosts/riot.conf
@@ -2,7 +2,7 @@
 
 server {
     listen 80;
-    server_name l3cdn.riotgames.com;
+    server_name l3cdn.riotgames.com worldwide.l3cdn.riotgames.com;
 
     # League of Legends Game CDN
     # * Uses multiple small package files with 200 requests

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -51,6 +51,7 @@ local-data: "akamai.steamusercontent.com. IN A 127.0.0.1"  # Steam
 
 local-zone: "riotgames.com." transparent
 local-data: "l3cdn.riotgames.com. IN A 127.0.0.1"  # Riot
+local-data: "worldwide.l3cdn.riotgames.com. IN A 127.0.0.1"  # Riot
 
 
 # leagueoflegends.com


### PR DESCRIPTION
In some regions, a different CNAME endpoint is used for Riot downloads. This is the same content server, so we simply add it to the list of cached servers.
