### PR TITLE
Xbox cache support

### DIFF
--- a/nginx/config/vhosts/xbox.conf
+++ b/nginx/config/vhosts/xbox.conf
@@ -2,8 +2,7 @@
 
 server {
     listen 80;
-    server_name dlassets.xboxlive.com
-                images-eds.xboxlive.com xbox-mbr.xboxlive.com
+    server_name dlassets.xboxlive.com xbox-mbr.xboxlive.com
                 *.xboxone.loris.llnwd.net xboxone.vo.llnwd.net;
 
     # Xbox One downloader:
@@ -38,5 +37,22 @@ server {
         # We need to copy the variable as it's not available after the pass starts
         set $location $upstream_http_location;
         proxy_pass $location;
+    }
+}
+
+server {
+    listen 80;
+    server_name images-eds.xboxlive.com;
+
+    # Application thumbnails, etc
+    # * Query parameters contain all data for image endpoint
+    # * Only regular requests
+    # * Cache control appropriately set
+
+    location / {
+        proxy_cache_key "qcacher-xbox$request_uri";
+        proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
     }
 }

--- a/nginx/config/vhosts/xbox.conf
+++ b/nginx/config/vhosts/xbox.conf
@@ -2,28 +2,35 @@
 
 server {
     listen 80;
-    server_name dlassets.xboxlive.com xbox-mbr.xboxlive.com
-                assets1.xboxlive.com.nsatc.net assets1.xboxlive.com
-                *.xboxone.loris.llnwd.net xboxone.vo.llnwd.net;
+    server_name dlassets.xboxlive.com;
 
-    # Xbox One downloader:
-    # * Uses a single archive file with range requests.
-    # * Uses redirects sometimes to push off to 3rd party CDNs.
-    # * Mainly uses 696320 byte requests?
+    # Xbox One content server
+    # * Provides proper Cache-Control settings, but doesn't set Expires
+    # * Uses reqular requests for small files, like JSON
+    # * Mainly uses 696320 byte range requests for large content files
+    # * Sometimes uses redirects to push off to 3rd party CDNs
 
-    # Ensure we don't cache redirects to 3rd party CDNs
-    error_page 301 302 307 = @redirect;
-    recursive_error_pages on;
-    proxy_intercept_errors on;
+    location /public/content/ {
+        # Xbox One application content
 
-    proxy_hide_header Etag;
-    proxy_cache_key "qcacher-xbox$request_uri$slice_range";
-    proxy_cache_valid 200 206 90d;
-    slice 16m;
+        # Handle redirects to 3rd party CDNs
+        error_page 301 302 307 = @redirect;
+        recursive_error_pages on;
+        proxy_intercept_errors on;
 
-    location / {
-        # proxy_set_header directives aren't merged so must be here
+        # Range requests are guaranteed for large files so we'll
+        # slice in 16MB chunks and cache
+        slice 16m;
+        proxy_cache_valid 200 206 14d;
         proxy_set_header Range $slice_range;
+
+        # Content files dont seem to have any query specific content delivery
+        # so we cache based on just the URI excluding the query string
+        proxy_cache_key "qcacher-xbox$uri$slice_range";
+
+        # Cache-Control is good, Expires not set, so just ignore ETag
+        proxy_hide_header Etag;
+
         proxy_cache installs;
         include includes/proxy-base;
         proxy_pass http://$host$request_uri;
@@ -39,6 +46,12 @@ server {
         set $location $upstream_http_location;
         proxy_pass $location;
     }
+
+    location / {
+        # Just pass through everything else
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
 }
 
 server {
@@ -50,9 +63,31 @@ server {
     # * Only regular requests
     # * Cache control appropriately set
 
-    location / {
+    location /image {
         proxy_cache_key "qcacher-xbox$request_uri";
         proxy_cache other;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location / {
+        # Just pass through everything else
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+}
+
+server {
+    listen 80;
+    server_name xbox-mbr.xboxlive.com
+                assets1.xboxlive.com.nsatc.net assets1.xboxlive.com
+                *.xboxone.loris.llnwd.net xboxone.vo.llnwd.net;
+
+    # Unknown XBox servers
+    # * Let's keep track of these for now, but pass them through
+
+    location / {
+        # Pass through everything
         include includes/proxy-base;
         proxy_pass http://$host$request_uri;
     }

--- a/nginx/config/vhosts/xbox.conf
+++ b/nginx/config/vhosts/xbox.conf
@@ -3,6 +3,7 @@
 server {
     listen 80;
     server_name dlassets.xboxlive.com xbox-mbr.xboxlive.com
+                assets1.xboxlive.com.nsatc.net assets1.xboxlive.com
                 *.xboxone.loris.llnwd.net xboxone.vo.llnwd.net;
 
     # Xbox One downloader:

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -175,5 +175,12 @@ local-data: "download.windowsupdate.com. IN A 127.0.0.1"  # Windows
 
 local-zone: "xboxlive.com." transparent
 local-data: "dlassets.xboxlive.com. IN A 127.0.0.1"  # Xbox
+local-data: "assets1.xboxlive.com. IN A 127.0.0.1"  # Xbox
 local-data: "images-eds.xboxlive.com. IN A 127.0.0.1"  # Xbox
 local-data: "xbox-mbr.xboxlive.com. IN A 127.0.0.1"  # Xbox
+
+
+# nsatc.net
+
+local-zone: "nsatc.com." transparent
+local-data: "assets1.xboxlive.com.nsatc.net. IN A 127.0.0.1"  # Xbox


### PR DESCRIPTION
This is a rewrite of Xbox's CDN support. Nodes that are tested have been configured, with remaining traffic being passed through until we can determine how to configure them.
