### PR TITLE
Nintendo CDN support for Wii U

### DIFF
--- a/nginx/config/vhosts/nintendo.conf
+++ b/nginx/config/vhosts/nintendo.conf
@@ -1,0 +1,45 @@
+# Nintendo Node
+
+server {
+    listen 80;
+    server_name conntest.nintendowifi.net;
+
+    # Nintendo WiFi connection test
+    # * Expects a 200 response
+    # * Expects a Nintendo server header
+
+    location / {
+        add_header X-Organization Nintendo;
+        return 200;
+    }
+}
+
+server {
+    listen 80;
+    server_name ccs.cdn.wup.shop.nintendo.net;
+
+    # Nintendo Content server
+    # * many binary files, wildly varying in size
+    # * no range requests
+    # * server provides Cache-Control, but it is restrictive on large files
+
+    location /ccs/ {
+        # Content
+
+        proxy_cache_valid 200 10m;
+        proxy_cache_key "qcacher-nintendo$request_uri";
+
+        # Nintendo's Cache-Control is restrictive
+        proxy_ignore_headers Cache-Control;
+
+        proxy_cache installs;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location / {
+        # Just pass through everything else
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+}

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -102,6 +102,18 @@ local-zone: "hi-rezgame.net." transparent
 local-data: "hzweb.hi-rezgame.net. IN A 127.0.0.1"  # Hirez
 
 
+# nintendowifi.net
+
+local-zone: "nintendowifi.net." transparent
+local-data: "conntest.nintendowifi.net. IN A 127.0.0.1"  # Nintendo
+
+
+# nintendo.net
+
+local-zone: "nintendo.net." transparent
+local-data: "ccs.cdn.wup.shop.nintendo.net. IN A 127.0.0.1"  # Nintendo
+
+
 # ea.com
 
 local-zone: "ea.com." transparent


### PR DESCRIPTION
- Add support for caching Wii U download content
- Always succeed on connection tests on our side (for improved offline support)

3DS CDN is not configured, and testing shows that 3DS online use is not affected by this PR. Later work will be done to better provide support for 3DS CDN endpoints.
