### PR TITLE
Minecraft download support

### DIFF
--- a/nginx/config/vhosts/minecraft.conf
+++ b/nginx/config/vhosts/minecraft.conf
@@ -1,0 +1,27 @@
+# Minecraft Node
+
+server {
+    listen 80;
+    server_name qcacher-minecraft s3.amazonaws.com;
+    access_log /var/log/nginx/qcacher-minecraft-access.log main buffer=128k flush=1m;
+    error_log /var/log/nginx/qcacher-minecraft-error.log;
+
+    # Some information available here:
+    # http://www.archiveteam.org/index.php?title=Minecraft.net#Site_structure
+
+    location /Minecraft.Download/ {
+        # Mojang seem to update Last-Modified, but don't pass on any caching
+        # information
+        proxy_cache_valid 200 90d;
+        proxy_cache_key "$server_name$request_uri";
+        proxy_cache installs;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+
+    location / {
+        # Pass through other S3 content
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+}

--- a/nginx/config/vhosts/s3aws.conf
+++ b/nginx/config/vhosts/s3aws.conf
@@ -1,14 +1,14 @@
-# Minecraft Node
+# Amazon S3 Node
 
 server {
     listen 80;
-    server_name qcacher-minecraft s3.amazonaws.com;
-    access_log /var/log/nginx/qcacher-minecraft-access.log main buffer=128k flush=1m;
-    error_log /var/log/nginx/qcacher-minecraft-error.log;
+    server_name qcacher-s3aws s3.amazonaws.com;
+    access_log /var/log/nginx/qcacher-s3aws-access.log main buffer=128k flush=1m;
+    error_log /var/log/nginx/qcacher-s3aws-error.log;
 
+    # Minecraft support
     # Some information available here:
     # http://www.archiveteam.org/index.php?title=Minecraft.net#Site_structure
-
     location /Minecraft.Download/ {
         # Mojang seem to update Last-Modified, but don't pass on any caching
         # information

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -168,7 +168,7 @@ local-data: "hls.ttvnw.net. IN A 127.0.0.1"  # Twitch
 # amazonaws.com
 
 local-zone: "amazonaws.com." transparent
-local-data: "s3.amazonaws.com. IN A 127.0.0.1"  # Minecraft
+local-data: "s3.amazonaws.com. IN A 127.0.0.1"  # s3aws
 
 
 # windowsupdate.com

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -165,6 +165,12 @@ local-zone: "hls.ttvnw.net." redirect
 local-data: "hls.ttvnw.net. IN A 127.0.0.1"  # Twitch
 
 
+# amazonaws.com
+
+local-zone: "amazonaws.com." transparent
+local-data: "s3.amazonaws.com. IN A 127.0.0.1"  # Minecraft
+
+
 # windowsupdate.com
 
 local-zone: "download.windowsupdate.com." redirect


### PR DESCRIPTION
Initial cache support for Minecraft assets served over HTTP. This spoofs Amazon S3 endpoint so we create this as a generic support for S3, and only force caching on the relevant paths.
