### PR TITLE
Add support for nvidia graphics driver updates

### DIFF
--- a/nginx/config/vhosts/nvidia.conf
+++ b/nginx/config/vhosts/nvidia.conf
@@ -1,0 +1,20 @@
+# NVIDIA Node
+
+server {
+    listen 80;
+    server_name qcacher-nvidia international-gfe.download.nvidia.com;
+    access_log /var/log/nginx/qcacher-nvidia-access.log main buffer=128k flush=1m;
+    error_log /var/log/nginx/qcacher-nvidia-error.log;
+
+    # Nvidia updates
+    location / {
+        slice 16m;
+        proxy_set_header Range $slice_range;
+        proxy_hide_header Etag;
+        proxy_cache_key "$server_name$request_uri$slice_range";
+        proxy_cache_valid 200 206 14d;
+        proxy_cache installs;
+        include includes/proxy-base;
+        proxy_pass http://$host$request_uri;
+    }
+}

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -183,6 +183,12 @@ local-zone: "amazonaws.com." transparent
 local-data: "s3.amazonaws.com. IN A 127.0.0.1"  # s3aws
 
 
+# nvidia.com
+
+local-zone: "nvidia.com." transparent
+local-data: "international-gfe.download.nvidia.com. IN A 127.0.0.1"  # NVIDIA
+
+
 # windowsupdate.com
 
 local-zone: "download.windowsupdate.com." redirect


### PR DESCRIPTION
Nvidia's download server is simple, and makes multiple range requests for a single large file. This is a simple override, and may be extended in future.
