### PR TITLE
Nginx updates

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.9-alpine
+FROM nginx:1.12-alpine
 MAINTAINER Dan Porter <dpreid@gmail.com>
 
 COPY config /etc/nginx

--- a/nginx/config/conf.d/02_caches
+++ b/nginx/config/conf.d/02_caches
@@ -1,4 +1,4 @@
-proxy_cache_path /srv/installs levels=2:2 keys_zone=installs:1000m inactive=365d max_size=972800m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
-proxy_cache_path /srv/live levels=2:2 keys_zone=live:10m inactive=1h max_size=1000m;
-proxy_cache_path /srv/other levels=2:2 keys_zone=other:100m inactive=72h max_size=10240m;
+proxy_cache_path /srv/installs levels=2:2 keys_zone=installs:1000m inactive=365d max_size=380000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path /srv/live levels=2:2 keys_zone=live:10m inactive=1h max_size=500m;
+proxy_cache_path /srv/other levels=2:2 keys_zone=other:100m inactive=72h max_size=5120m;
 proxy_temp_path /srv/tmp;

--- a/nginx/config/conf.d/04_proxy
+++ b/nginx/config/conf.d/04_proxy
@@ -16,8 +16,9 @@ proxy_cache_lock_timeout 4h;
 # Allow the use of state entries
 proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
 
-# Enable cache revalidation
+# Enable cache revalidation, and background updating
 proxy_cache_revalidate on;
+proxy_cache_background_update on;
 
 # By-pass with nocache=1
 proxy_cache_bypass $arg_nocache;

--- a/nginx/config/vhosts/blizzard.conf
+++ b/nginx/config/vhosts/blizzard.conf
@@ -16,7 +16,7 @@ server {
         slice 16m;
         proxy_set_header Range $slice_range;
         proxy_hide_header ETag;
-        proxy_cache_key "qcacher-blizzard$request_uri$slice_range";
+        proxy_cache_key "blizzard02$request_uri$slice_range";
         proxy_cache_valid 200 206 14d;
         proxy_cache installs;
         include includes/proxy-base;

--- a/nginx/config/vhosts/hirez.conf
+++ b/nginx/config/vhosts/hirez.conf
@@ -12,7 +12,7 @@ server {
     # We don't cache the main download as thats on *.hwcdn.net which containts lots
     # more than just hirez e.g. store.steampowered.com which is https.
 
-    proxy_cache_key "qcacher-hirez$request_uri";
+    proxy_cache_key "hirez02$request_uri";
     proxy_cache_valid 200 48h;
 
     location / {

--- a/nginx/config/vhosts/mozilla.conf
+++ b/nginx/config/vhosts/mozilla.conf
@@ -13,7 +13,7 @@ server {
         slice 300000;
         proxy_set_header Range $slice_range;
         proxy_hide_header ETag;
-        proxy_cache_key "$server_name$request_uri$slice_range";
+        proxy_cache_key "mozilla02$request_uri$slice_range";
         proxy_cache_valid 200 206 14d;
         proxy_cache installs;
         include includes/proxy-base;

--- a/nginx/config/vhosts/nintendo.conf
+++ b/nginx/config/vhosts/nintendo.conf
@@ -27,7 +27,7 @@ server {
         # Content
 
         proxy_cache_valid 200 10m;
-        proxy_cache_key "qcacher-nintendo$request_uri";
+        proxy_cache_key "nintendo02$request_uri";
 
         # Nintendo's Cache-Control is restrictive
         proxy_ignore_headers Cache-Control;

--- a/nginx/config/vhosts/nvidia.conf
+++ b/nginx/config/vhosts/nvidia.conf
@@ -9,7 +9,7 @@ server {
         slice 16m;
         proxy_set_header Range $slice_range;
         proxy_hide_header ETag;
-        proxy_cache_key "$server_name$request_uri$slice_range";
+        proxy_cache_key "nvidia02$request_uri$slice_range";
         proxy_cache_valid 200 206 14d;
         proxy_cache installs;
         include includes/proxy-base;

--- a/nginx/config/vhosts/origin.conf
+++ b/nginx/config/vhosts/origin.conf
@@ -15,7 +15,7 @@ server {
         slice 16m;
         proxy_set_header Range $slice_range;
         proxy_hide_header ETag;
-        proxy_cache_key "qcacher-origin$uri$slice_range";
+        proxy_cache_key "origin02$uri$slice_range";
         proxy_cache_valid 200 206 14d;
         proxy_cache installs;
         include includes/proxy-base;

--- a/nginx/config/vhosts/planetside.conf
+++ b/nginx/config/vhosts/planetside.conf
@@ -10,7 +10,7 @@ server {
 
     location / {
         proxy_hide_header ETag;
-        proxy_cache_key "qcacher-planetside$request_uri";
+        proxy_cache_key "planetside02$request_uri";
         proxy_cache_valid 200 206 14d;
         proxy_cache installs;
         include includes/proxy-base;
@@ -28,7 +28,7 @@ server {
 
     location / {
         proxy_hide_header ETag;
-        proxy_cache_key "qcacher-planetside$request_uri";
+        proxy_cache_key "planetside02$request_uri";
         proxy_cache_valid 200 3m;
         proxy_cache other;
         include includes/proxy-base;

--- a/nginx/config/vhosts/psn.conf
+++ b/nginx/config/vhosts/psn.conf
@@ -16,7 +16,7 @@ server {
         # Update lists
         # * Unique per region - XML is region tagged
         # * Can change at any point, so revalidate
-        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_key "psn02$request_uri";
         proxy_cache_valid 200 1m;
         proxy_cache other;
         include includes/proxy-base;
@@ -31,7 +31,7 @@ server {
         slice 16m;
         proxy_set_header Range $slice_range;
         proxy_hide_header ETag;
-        proxy_cache_key "qcacher-psn$uri$slice_range";
+        proxy_cache_key "psn02$uri$slice_range";
         proxy_cache_valid 200 206 14d;
         proxy_cache installs;
         include includes/proxy-base;
@@ -59,7 +59,7 @@ server {
     # * PSN-RSC used by PS4
 
     location / {
-        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_key "psn02$request_uri";
         proxy_cache_valid 200 14d;
         proxy_cache other;
         include includes/proxy-base;
@@ -77,7 +77,7 @@ server {
 
     location ~ /tmdb2?/ {
 
-        proxy_cache_key "qcacher-psn$request_uri";
+        proxy_cache_key "psn02$request_uri";
         proxy_cache_valid 200 1m;
         proxy_cache other;
         include includes/proxy-base;
@@ -117,7 +117,7 @@ server {
 
         # Looks like PS passes security parameters on the URI so we
         # cache based on just the URI excluding the query string
-        proxy_cache_key "qcacher-psn$uri$slice_range";
+        proxy_cache_key "psn02$uri$slice_range";
 
         # PSN's Cache-Control and Expires are restrictive
         proxy_ignore_headers Expires Cache-Control;
@@ -139,7 +139,7 @@ server {
 
         # Looks like PS passes security parameters on the URI so we
         # cache based on just the URI excluding the query string
-        proxy_cache_key "qcacher-psn$uri$slice_range";
+        proxy_cache_key "psn02$uri$slice_range";
 
         # PSN's Cache-Control and Expires are restrictive
         proxy_ignore_headers Expires Cache-Control;
@@ -154,7 +154,7 @@ server {
 
     location /networktest/ {
         # Showing off the cache speed
-        proxy_cache_key "qcacher-psn$uri";
+        proxy_cache_key "psn02$uri";
         proxy_cache_valid 200 90d;
         proxy_cache other;
         include includes/proxy-base;

--- a/nginx/config/vhosts/riot.conf
+++ b/nginx/config/vhosts/riot.conf
@@ -10,7 +10,7 @@ server {
     #   revalidate
     # * Correctly defines no-cache for release listings and manifests
 
-    proxy_cache_key "qcacher-riot$request_uri";
+    proxy_cache_key "riot02$request_uri";
     proxy_cache_valid 200 14d;
 
     location / {
@@ -28,7 +28,7 @@ server {
     # * Correctly defines Cache-Control and Expires headers, so we'll cache
     #   what they let us
 
-    proxy_cache_key "qcacher-riot$request_uri";
+    proxy_cache_key "riot02$request_uri";
 
     location / {
         proxy_cache other;

--- a/nginx/config/vhosts/s3aws.conf
+++ b/nginx/config/vhosts/s3aws.conf
@@ -11,7 +11,7 @@ server {
         # Mojang seem to update Last-Modified, but don't pass on any caching
         # information
         proxy_cache_valid 200 90d;
-        proxy_cache_key "$server_name$request_uri";
+        proxy_cache_key "s3aws02$request_uri";
         proxy_cache installs;
         include includes/proxy-base;
         proxy_pass http://$host$request_uri;

--- a/nginx/config/vhosts/steam.conf
+++ b/nginx/config/vhosts/steam.conf
@@ -19,7 +19,7 @@ server {
 
         # Steam sometimes passes security parameters on the URI so we
         # cache based on just the URI excluding the query string
-        proxy_cache_key "qcacher-steam$uri";
+        proxy_cache_key "steam02$uri";
         proxy_cache installs;
         include includes/proxy-base;
         proxy_pass http://$host$request_uri;
@@ -30,7 +30,7 @@ server {
     # * No Cache-Control defined, we will set 5m
     # * Use live cache for quick expunging
     location ~ ^/(broadcast|chat)/ {
-        proxy_cache_key "qcacher-steam$uri";
+        proxy_cache_key "steam02$uri";
         proxy_cache live;
         proxy_cache_valid 200 5m;
         include includes/proxy-base;
@@ -39,7 +39,7 @@ server {
 
     # Proxy everything else (caching if suggested)
     location / {
-        proxy_cache_key "qcacher-steam$request_uri";
+        proxy_cache_key "steam02$request_uri";
         proxy_cache other;
         include includes/proxy-base;
         proxy_pass http://$host$request_uri;
@@ -58,7 +58,7 @@ server {
     # * Query params are important (asset versions) so we must include these
     #   in the key
 
-    proxy_cache_key "qcacher-steam$request_uri";
+    proxy_cache_key "steam02$request_uri";
     proxy_cache other;
     proxy_cache_valid 200 14d;
 
@@ -77,7 +77,7 @@ server {
     # * Query parameters for media servers are important
     # * Cache anything they let us
 
-    proxy_cache_key "qcacher-steam$request_uri";
+    proxy_cache_key "steam02$request_uri";
     proxy_cache other;
 
     location / {

--- a/nginx/config/vhosts/twitch.conf
+++ b/nginx/config/vhosts/twitch.conf
@@ -9,7 +9,7 @@ server {
     server_name .hls.justin.tv .hls.twitch.tv .hls.ttvnw.net;
 
     # Twitch broadcasts
-    proxy_cache_key "qcacher-twitch$uri";
+    proxy_cache_key "twitch02$uri";
     proxy_cache live;
 
     location / {
@@ -37,7 +37,7 @@ server {
     # Twitch channel playlists
     # * Provide quality information which we want to filter
 
-    proxy_cache_key "qcacher-twitch$uri";
+    proxy_cache_key "twitch02$uri";
     proxy_cache live;
 
     location ~ \.m3u8$ {

--- a/nginx/config/vhosts/windows.conf
+++ b/nginx/config/vhosts/windows.conf
@@ -11,7 +11,7 @@ server {
     # * Correctly sets Cache-Control headers (usually 48h)
 
     proxy_hide_header ETag;
-    proxy_cache_key "qcacher-windows$request_uri$slice_range";
+    proxy_cache_key "windows02$request_uri$slice_range";
     slice 4m;
 
     location / {

--- a/nginx/config/vhosts/xbox.conf
+++ b/nginx/config/vhosts/xbox.conf
@@ -26,7 +26,7 @@ server {
 
         # Content files dont seem to have any query specific content delivery
         # so we cache based on just the URI excluding the query string
-        proxy_cache_key "qcacher-xbox$uri$slice_range";
+        proxy_cache_key "xbox02$uri$slice_range";
 
         # Cache-Control is good, Expires not set, so just ignore ETag
         proxy_hide_header ETag;
@@ -64,7 +64,7 @@ server {
     # * Cache control appropriately set
 
     location /image {
-        proxy_cache_key "qcacher-xbox$request_uri";
+        proxy_cache_key "xbox02$request_uri";
         proxy_cache other;
         include includes/proxy-base;
         proxy_pass http://$host$request_uri;


### PR DESCRIPTION
Bringing nearly a year of updates to nginx, we also update the following:

* Cached content is now <400GB
* Stale assets now update in the background, rather than block
* Caching key format updated, and current cache invalidated