### PR TITLE
Sniproxy 0.5 with Alpine Linux

### DIFF
--- a/sniproxy/Dockerfile
+++ b/sniproxy/Dockerfile
@@ -1,15 +1,38 @@
-FROM ubuntu:trusty
+FROM alpine:3.5
+
 MAINTAINER Dan Porter <dpreid@gmail.com>
 
-RUN set -x && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ED122FA0 && \
-    echo "deb http://ppa.launchpad.net/dlundquist/sniproxy/ubuntu trusty main" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y --no-install-recommends \
-        sniproxy && \
-    rm -rf /var/lib/apt/lists/*
+ENV SNIPROXY_VERSION=0.5.0 \
+    SNIPROXY_SHASUM="0b8dd06f9aa9e1c4151b572caf645ffceacdd35a139ded16a7fb0035452c17e5"
 
-COPY sniproxy.conf /etc/sniproxy/sniproxy.conf
+RUN apk --no-cache --virtual build-dependencies add \
+        libressl \
+        autoconf \
+        automake \
+        build-base \
+        gettext-dev \
+        libev-dev \
+        pcre-dev \
+        udns-dev \
+        bsd-compat-headers \
+    && mkdir -p /tmp/build \
+    && wget -O /tmp/build/${SNIPROXY_VERSION}.tar.gz https://github.com/dlundquist/sniproxy/archive/${SNIPROXY_VERSION}.tar.gz \
+    && echo "${SNIPROXY_SHASUM}  /tmp/build/${SNIPROXY_VERSION}.tar.gz" | sha256sum -c \
+    && tar -xzf /tmp/build/${SNIPROXY_VERSION}.tar.gz -C /tmp/build/ \
+    && cd /tmp/build/sniproxy-${SNIPROXY_VERSION} \
+    && ./autogen.sh \
+    && ./configure \
+    && make install \
+    && cd / \
+    && rm -rf /tmp/build \
+    && apk --no-cache add \
+        libev \
+        pcre \
+        udns \
+    && apk --no-cache --purge del build-dependencies
+
+COPY sniproxy.conf /etc/sniproxy.conf
 
 EXPOSE 443
 
-CMD ["/usr/sbin/sniproxy", "-f", "-c", "/etc/sniproxy/sniproxy.conf"]
+CMD ["sniproxy", "-f"]

--- a/sniproxy/sniproxy.conf
+++ b/sniproxy/sniproxy.conf
@@ -1,8 +1,8 @@
 user nobody
-pidfile /var/tmp/sniproxy.pid
+group nogroup
+
 resolver {
     nameserver 8.8.8.8
-    search example.com
     mode ipv4_only
 }
 


### PR DESCRIPTION
Sniproxy has been updated to 0.5.0, and rebuilt to use Alpine Linux as it's base. The result is a far smaller image, and many bugfixes from the upstream release.