### PR TITLE
Feature: 3DS cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We currently support content caching and delivery for the following services:
 
 * PlayStation Network (PS3 & PS4)
 * Xbox Live (**untested**)
+* Nintendo (3DS & Wii U)
 * Blizzard (Starcraft 2, Hearthstone, etc.)
 * Riot (League of Legends)
 * Steam (Broadcasts, Games, etc.)

--- a/nginx/config/vhosts/nintendo.conf
+++ b/nginx/config/vhosts/nintendo.conf
@@ -16,7 +16,8 @@ server {
 
 server {
     listen 80;
-    server_name ccs.cdn.wup.shop.nintendo.net;
+    server_name ccs.cdn.wup.shop.nintendo.net
+                ccs.cdn.c.shop.nintendowifi.net;
 
     # Nintendo Content server
     # * many binary files, wildly varying in size

--- a/unbound/qcacher.conf
+++ b/unbound/qcacher.conf
@@ -107,6 +107,7 @@ local-data: "hzweb.hi-rezgame.net. IN A 127.0.0.1"  # Hirez
 
 local-zone: "nintendowifi.net." transparent
 local-data: "conntest.nintendowifi.net. IN A 127.0.0.1"  # Nintendo
+local-data: "ccs.cdn.c.shop.nintendowifi.net. IN A 127.0.0.1"  # Nintendo
 
 
 # nintendo.net


### PR DESCRIPTION
Support for the endpoint the 3DS uses to retrieve content from Nintendo servers has been added. Documentation has been updated to reflect the recent addition of Nintendo CDN support.